### PR TITLE
Editor actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ This module provides a set of shortcuts with links to execute common DKAN
 tasks. You can import the shortcuts by running the Drush command:
 
 ```
-drush dkan_roles:shortcut
+drush dkan_roles:shortcuts
 ```

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ Permissions:
 - Create dataset, resource, data story, and data dashboard content.
 - Edit own content (can not edit content added by another user).
 - View own unpublished content and revision history of all published content.
+
+## Shortcuts
+This module provides a set of shortcuts with links to execute common DKAN
+tasks. You can import the shortcuts by running the Drush command:
+
+```
+drush dkan_roles:shortcut
+```

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "minimum-stability": "dev",
     "description": "Define common user roles for a DKAN install.",
     "require": {
+        "drupal/default_content": "^2.0@alpha",
         "php": "^7.2"
     },
     "repositories": [

--- a/config/install/shortcut.set.dkan-shortcuts.yml
+++ b/config/install/shortcut.set.dkan-shortcuts.yml
@@ -1,0 +1,5 @@
+langcode: en
+status: true
+dependencies: {  }
+id: dkan-shortcuts
+label: 'DKAN Shortcuts'

--- a/config/install/user.role.editor.yml
+++ b/config/install/user.role.editor.yml
@@ -6,8 +6,10 @@ label: Editor
 weight: 4
 is_admin: null
 permissions:
+  - 'access content overview'
   - 'access toolbar'
   - 'access user profiles'
+  - 'administer nodes'
   - 'cancel account'
   - 'create data content'
   - 'delete any data content'

--- a/content/shortcut/757fa9fd-c5a4-4cc7-ac88-a57e0e4aec35.yml
+++ b/content/shortcut/757fa9fd-c5a4-4cc7-ac88-a57e0e4aec35.yml
@@ -1,0 +1,18 @@
+_meta:
+  version: '1.0'
+  entity_type: shortcut
+  uuid: 757fa9fd-c5a4-4cc7-ac88-a57e0e4aec35
+  bundle: dkan-shortcuts
+  default_langcode: en
+default:
+  title:
+    -
+      value: Datasets
+  weight:
+    -
+      value: -9
+  link:
+    -
+      uri: 'internal:/admin/content/datasets'
+      title: ''
+      options: {  }

--- a/content/shortcut/886f3bf6-94f2-473b-9ccc-6ee52a81fb0c.yml
+++ b/content/shortcut/886f3bf6-94f2-473b-9ccc-6ee52a81fb0c.yml
@@ -1,0 +1,18 @@
+_meta:
+  version: '1.0'
+  entity_type: shortcut
+  uuid: 886f3bf6-94f2-473b-9ccc-6ee52a81fb0c
+  bundle: dkan-shortcuts
+  default_langcode: en
+default:
+  title:
+    -
+      value: 'Create a dataset'
+  weight:
+    -
+      value: -10
+  link:
+    -
+      uri: 'internal:/node/add/data'
+      title: ''
+      options: {  }

--- a/content/shortcut/8c053454-f82e-4750-b4c9-27b63ca6a23d.yml
+++ b/content/shortcut/8c053454-f82e-4750-b4c9-27b63ca6a23d.yml
@@ -1,0 +1,18 @@
+_meta:
+  version: '1.0'
+  entity_type: shortcut
+  uuid: 8c053454-f82e-4750-b4c9-27b63ca6a23d
+  bundle: dkan-shortcuts
+  default_langcode: en
+default:
+  title:
+    -
+      value: Content
+  weight:
+    -
+      value: -8
+  link:
+    -
+      uri: 'internal:/admin/content/node'
+      title: ''
+      options: {  }

--- a/content/shortcut/96f96ca4-233d-4544-84c2-fd07f2bf2f37.yml
+++ b/content/shortcut/96f96ca4-233d-4544-84c2-fd07f2bf2f37.yml
@@ -1,0 +1,18 @@
+_meta:
+  version: '1.0'
+  entity_type: shortcut
+  uuid: 96f96ca4-233d-4544-84c2-fd07f2bf2f37
+  bundle: dkan-shortcuts
+  default_langcode: en
+default:
+  title:
+    -
+      value: 'Moderated content'
+  weight:
+    -
+      value: -7
+  link:
+    -
+      uri: 'internal:/admin/content/moderated'
+      title: ''
+      options: {  }

--- a/dkan_roles.info.yml
+++ b/dkan_roles.info.yml
@@ -3,3 +3,14 @@ type: module
 description: 'Define common user roles for a DKAN install.'
 package: DKAN
 core_version_requirement: '^8 || ^9'
+
+dependencies:
+  - shortcut
+  - default_content
+
+default_content:
+  shortcut:
+    - 886f3bf6-94f2-473b-9ccc-6ee52a81fb0c
+    - 757fa9fd-c5a4-4cc7-ac88-a57e0e4aec35
+    - 8c053454-f82e-4750-b4c9-27b63ca6a23d
+    - 96f96ca4-233d-4544-84c2-fd07f2bf2f37

--- a/dkan_roles.install
+++ b/dkan_roles.install
@@ -5,16 +5,9 @@
  */
 
 /**
- * Enable shortcut module.
+ * Enable shortcut and default_content modules.
  */
 function dkan_roles_update_8002(){
   \Drupal::service('module_installer')->install(['shortcut']);
-}
-
-/**
- * Import shortcuts.
- */
-function dkan_roles_update_8003() {
   \Drupal::service('module_installer')->install(['default_content']);
-  \Drupal::service('default_content.importer')->importContent('dkan_roles');
 }

--- a/dkan_roles.install
+++ b/dkan_roles.install
@@ -10,3 +10,11 @@
 function dkan_roles_update_8002(){
   \Drupal::service('module_installer')->install(['shortcut']);
 }
+
+/**
+ * Import shortcuts.
+ */
+function dkan_roles_update_8003() {
+  \Drupal::service('module_installer')->install(['default_content']);
+  \Drupal::service('default_content.importer')->importContent('dkan_roles');
+}

--- a/dkan_roles.install
+++ b/dkan_roles.install
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Install file for dkan_roles.
+ */
+
+/**
+ * Enable shortcut module.
+ */
+function dkan_roles_update_8002(){
+  \Drupal::service('module_installer')->install(['shortcut']);
+}

--- a/dkan_roles.module
+++ b/dkan_roles.module
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Hook implementations for dkan_roles.
+ */
+
+/**
+ * Implements hook_shortcut_default_set().
+ */
+function dkan_roles_shortcut_default_set($account) {
+  return 'dkan-shortcuts';
+}

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+  dkan_roles.commands:
+    class: \Drupal\dkan_roles\Commands\DkanRolesCommands
+    tags:
+      - { name: drush.command }

--- a/src/Commands/DkanRolesCommands.php
+++ b/src/Commands/DkanRolesCommands.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\dkan_roles\Commands;
+
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands.
+ */
+class DkanRolesCommands extends DrushCommands {
+
+  /**
+   * Drush command for importing shortcuts.
+   *
+   * @command dkan_roles:shortcuts
+   */
+  public function shortcuts() {
+    \Drupal::service('default_content.importer')->importContent('dkan_roles');
+  }
+
+}


### PR DESCRIPTION
fixes https://github.com/NuCivic/dkan_management/issues/437

## User story:
As a user with the role of Editor, I see links in the admin toolbar so that I can create a dataset and navigate through the content, list of datasets and moderated content.

## Acceptance Criteria:
Run `drush updb`, then `drush cim --partial --source=modules/contrib/dkan_roles/config/install` and then `drush dkan_roles:shortcuts`.
Then log in, you should see the following links in the shortcuts section:
- [ ] Create a dataset 
- [ ] Content
- [ ] Datasets
- [ ] Moderated content